### PR TITLE
feat: connect login to backend

### DIFF
--- a/pro-login.html
+++ b/pro-login.html
@@ -117,23 +117,36 @@
     });
 
     // Submit handler
-    form.addEventListener('submit', (e) => {
+    form.addEventListener('submit', async (e) => {
       e.preventDefault();
       const email = document.getElementById('email').value.trim();
       const password = pwd.value;
 
-      if (email === 'demo@fixhub.es' && password === 'demo123') {
-        window.location.href = 'pro.html';
-        return;
-      }
+      try {
+        const response = await fetch('https://tradex-be-production.up.railway.app/api/auth/login', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ email, password }),
+        });
 
-      alertBox.classList.remove('hidden');
-      alertBox.removeAttribute('aria-hidden');
-      alertBox.classList.remove('shake');
-      void alertBox.offsetWidth;
-      alertBox.classList.add('shake');
-      alertBox.setAttribute('tabindex', '-1');
-      alertBox.focus({ preventScroll: true });
+        if (!response.ok) throw new Error('Invalid credentials');
+
+        const data = await response.json();
+        if (data && data.token) {
+          localStorage.setItem('token', data.token);
+        }
+        window.location.href = 'pro.html';
+      } catch (error) {
+        alertBox.classList.remove('hidden');
+        alertBox.removeAttribute('aria-hidden');
+        alertBox.classList.remove('shake');
+        void alertBox.offsetWidth;
+        alertBox.classList.add('shake');
+        alertBox.setAttribute('tabindex', '-1');
+        alertBox.focus({ preventScroll: true });
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- use Tradex-BE API for login instead of hardcoded credentials

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac74e942bc8325b2a5b6d34a5608c7